### PR TITLE
Only update size when values are valid

### DIFF
--- a/editline/editline.go
+++ b/editline/editline.go
@@ -649,8 +649,12 @@ func (m *Model) Debug() string {
 }
 
 // SetSize changes the size of the editor.
+// NB: if one of the dimensions is zero, the call is a no-op.
 // NB: it only takes effect at the first next event processed.
 func (m *Model) SetSize(width, height int) {
+	if width == 0 || height == 0 {
+		return
+	}
 	m.hasNewSize = true
 	m.newWidth = width
 	m.newHeight = height

--- a/editline/testdata/bad_resize
+++ b/editline/testdata/bad_resize
@@ -1,0 +1,10 @@
+run
+reset
+resize 40 25
+resize 0 0
+----
+TEA WINDOW SIZE: {40 25}
+TEA WINDOW SIZE: {0 0}
+-- view:
+> [7m [0m                                   ␤
+M-? toggle key help • C-d erase/stop🛇


### PR DESCRIPTION
In some environments the ioctl call for window size will return 0x0, for instance in serial console setups. This causes the input to be truncated making it hard for users to see what they are typing. This performs a check to see if either width or height has a non-zero value before updating the size.