### PR TITLE
ci: update GitHub workflows for Go 1.24.x and modern action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.16, ^1]
+        go-version: [1.23.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,19 +5,19 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Download Go modules
         run: go mod download

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,7 @@ jobs:
   coverage:
     strategy:
       matrix:
-        go-version: [^1]
+        go-version: [1.23.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,18 +11,21 @@ jobs:
     env:
       GO111MODULE: "on"
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
       - name: Install Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Checkout code
-        uses: actions/checkout@v5
+      - name: Run tests with coverage
+        run: go test -race -covermode atomic -coverprofile=profile.cov ./...
 
-      - name: Coverage
+      - name: Install goveralls
+        run: go install github.com/mattn/goveralls@latest
+
+      - name: Send coverage
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          go test -race -covermode atomic -coverprofile=profile.cov ./...
-          GO111MODULE=off go get github.com/mattn/goveralls
-          $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github
+        run: goveralls -coverprofile=profile.cov -service=github

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,19 +5,19 @@ jobs:
   coverage:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Coverage
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1
+          go-version: 1.23.x
 
       - uses: actions/checkout@v3
       - name: golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         with:
           # Optional: golangci-lint command line arguments.
           #args:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/knz/bubbline
 
-go 1.25.4
+go 1.24.2
 
 require (
 	github.com/atotto/clipboard v0.1.4
@@ -11,6 +11,7 @@ require (
 	github.com/knz/catwalk v0.1.4
 	github.com/mattn/go-runewidth v0.0.19
 	github.com/muesli/reflow v0.3.0
+	github.com/muesli/termenv v0.16.0
 	golang.org/x/sys v0.38.0
 )
 
@@ -32,7 +33,6 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect


### PR DESCRIPTION
This PR modernizes the GitHub Actions CI:

- Update actions - checkout@v5 and setup-go@v6
- Switch workflows to Go 1.24.x (matching BubbleTea)
- Replace deprecated go get with go install in coverage workflow
- All workflows (build, lint, coverage) now pass successfully
